### PR TITLE
agregar clave zona a oficinas, aceptar varios datos en campo clave zonas

### DIFF
--- a/apps/backend/src/oficinas/dto/agregar-clave-zona.dto.ts
+++ b/apps/backend/src/oficinas/dto/agregar-clave-zona.dto.ts
@@ -1,0 +1,17 @@
+import { IsString, IsNotEmpty, Length, Matches } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AgregarClaveZonaDto {
+  @ApiProperty({
+    example: '00304',
+    description: 'Clave de la zona a agregar a la oficina',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @Length(5, 5, { message: 'La claveZona debe tener exactamente 5 caracteres' })
+  @Matches(/^\d{5}$/, { message: 'La claveZona debe contener solo números' })
+
+  claveZona: string;
+}
+
+

--- a/apps/backend/src/oficinas/dto/eliminar-clave-zona.dto.ts
+++ b/apps/backend/src/oficinas/dto/eliminar-clave-zona.dto.ts
@@ -1,0 +1,12 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class EliminarClaveZonaDto {
+  @ApiProperty({
+    example: '00304',
+    description: 'Clave de la zona a eliminar de la oficina',
+  })
+  @IsString()
+  @IsNotEmpty()
+  claveZona: string;
+}

--- a/apps/backend/src/oficinas/entities/oficina.entity.ts
+++ b/apps/backend/src/oficinas/entities/oficina.entity.ts
@@ -73,7 +73,7 @@ export class Oficina {
   @Column({ length: 5 })
   codigo_postal: string;
 
-  @Column({ length: 5, nullable: true })
+  @Column({ type: 'text', nullable: true })
   clave_unica_zona: string;
 
   @Column({ length: 20 })

--- a/apps/backend/src/oficinas/oficinas.controller.ts
+++ b/apps/backend/src/oficinas/oficinas.controller.ts
@@ -2,6 +2,8 @@ import { Controller, Get, Post, Body, Param, Put, Patch } from '@nestjs/common';
 import { OficinasService } from './oficinas.service';
 import { CreateOficinaDto } from './dto/create-oficina.dto';
 import { UpdateOficinaDto } from './dto/update-oficina.dto';
+import { AgregarClaveZonaDto } from './dto/agregar-clave-zona.dto';
+import { EliminarClaveZonaDto } from './dto/eliminar-clave-zona.dto';
 
 @Controller('oficinas')
 export class OficinasController {
@@ -50,5 +52,15 @@ export class OficinasController {
   @Patch(':id/activar')
   activate(@Param('id') id: number) {
     return this.oficinasService.activate(id);
+  }
+
+  @Patch(':cuo/agregar-clave-zona')
+  agregarClaveZona(@Param('cuo') cuo: string, @Body() dto: AgregarClaveZonaDto) {
+    return this.oficinasService.agregarClaveZona(cuo, dto);
+  }
+
+  @Patch(':cuo/eliminar-clave-zona')
+  eliminarClaveZona(@Param('cuo') cuo: string, @Body() dto: EliminarClaveZonaDto) {
+    return this.oficinasService.eliminarClaveZona(cuo, dto);
   }
 }

--- a/apps/backend/src/oficinas/oficinas.service.ts
+++ b/apps/backend/src/oficinas/oficinas.service.ts
@@ -4,6 +4,8 @@ import { Repository } from 'typeorm';
 import { Oficina } from './entities/oficina.entity';
 import { CreateOficinaDto } from './dto/create-oficina.dto';
 import { UpdateOficinaDto } from './dto/update-oficina.dto';
+import { AgregarClaveZonaDto } from './dto/agregar-clave-zona.dto';
+import { EliminarClaveZonaDto } from './dto/eliminar-clave-zona.dto';
 
 @Injectable()
 export class OficinasService {
@@ -75,4 +77,40 @@ export class OficinasService {
     await this.oficinaRepo.update(id, { activo: true });
     return { message: 'Oficina activada correctamente' };
   }
+
+  async agregarClaveZona(cuo: string, dto: AgregarClaveZonaDto) {
+    const oficina = await this.oficinaRepo.findOneBy({ clave_cuo: cuo });
+    if (!oficina) throw new NotFoundException('Oficina no encontrada');
+
+    if (dto.claveZona === cuo) {
+      throw new BadRequestException('No puedes asignar la misma clave CUO como clave de zona');
+    }
+
+    const clavesActuales = oficina.clave_unica_zona ? oficina.clave_unica_zona.split(',') : [];
+
+    if (clavesActuales.includes(dto.claveZona)) {
+      throw new BadRequestException('La clave ya existe en esta oficina');
+    }
+
+    clavesActuales.push(dto.claveZona);
+    oficina.clave_unica_zona = clavesActuales.join(',');
+    return this.oficinaRepo.save(oficina);
+  }
+
+
+  async eliminarClaveZona(cuo: string, dto: EliminarClaveZonaDto) {
+    const oficina = await this.oficinaRepo.findOneBy({ clave_cuo: cuo });
+    if (!oficina) throw new NotFoundException('Oficina no encontrada');
+
+    const clavesActuales = oficina.clave_unica_zona ? oficina.clave_unica_zona.split(',') : [];
+    const nuevasClaves = clavesActuales.filter(c => c !== dto.claveZona);
+
+    if (clavesActuales.length === nuevasClaves.length) {
+      throw new BadRequestException('La clave no existe en esta oficina');
+    }
+
+    oficina.clave_unica_zona = nuevasClaves.length > 0 ? nuevasClaves.join(',') : '';
+    return this.oficinaRepo.save(oficina);
+  }
+
 }


### PR DESCRIPTION
ahora estan los endpoints para asignar y eliminar las claves unicas de las oficinas a las que se pueden enrutar los vehiculos