### PR TITLE
test(guias): se agregaron los test unitarios con jest.

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -18,7 +18,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "test:guias": "jest --config src/guias_trazabilidad/__tests__/jest.config.js"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.859.0",

--- a/apps/backend/src/config/typeorm.config.ts
+++ b/apps/backend/src/config/typeorm.config.ts
@@ -14,5 +14,5 @@ export const typeOrmConfig = (
   ssl: true,
   logging: false,
   synchronize: true,
-  entities: [join(__dirname + '../../**/*.{js,ts}')],
+  entities: [join(__dirname + '../../**/*entity.{js,ts}')],
 });

--- a/apps/backend/src/guias_trazabilidad/__tests__/demo/simple-demo.spec.ts
+++ b/apps/backend/src/guias_trazabilidad/__tests__/demo/simple-demo.spec.ts
@@ -1,0 +1,107 @@
+import { Result } from 'src/utils/result';
+
+
+class MockHandler {
+  constructor(private dependencies: any) {}
+
+  async execute(command: any): Promise<Result<any>> {
+    if (command.shouldFail) {
+      return Result.failure('Simulated error');
+    }
+    
+    return Result.success({
+      success: true,
+      data: command.data
+    });
+  }
+}
+
+describe(' guias_trazabilidad - Tests', () => {
+  describe('Result Pattern', () => {
+    it('should create successful result', () => {
+      const result = Result.success('test data');
+      
+      expect(result.isFailure()).toBe(false);
+      expect(result.getValue()).toBe('test data');
+    });
+
+    it('should create failure result', () => {
+      const result = Result.failure('error message');
+      
+      expect(result.isFailure()).toBe(true);
+      expect(result.getError()).toBe('error message');
+    });
+  });
+
+  describe('Mock Handler Pattern', () => {
+    let handler: MockHandler;
+    let mockDependencies: any;
+
+    beforeEach(() => {
+      mockDependencies = {
+        repository: {
+          save: jest.fn(),
+          findById: jest.fn(),
+        },
+        service: {
+          process: jest.fn()
+        }
+      };
+
+      handler = new MockHandler(mockDependencies);
+    });
+
+    it('should handle successful execution', async () => {
+      const command = { data: 'test', shouldFail: false };
+      
+      const result = await handler.execute(command);
+      
+      expect(result.isFailure()).toBe(false);
+      expect(result.getValue()).toEqual({
+        success: true,
+        data: 'test'
+      });
+    });
+
+    it('should handle failed execution', async () => {
+      const command = { data: 'test', shouldFail: true };
+      
+      const result = await handler.execute(command);
+      
+      expect(result.isFailure()).toBe(true);
+      expect(result.getError()).toBe('Simulated error');
+    });
+
+    it('should use mocked dependencies', async () => {
+      mockDependencies.repository.findById.mockResolvedValue({ id: 1 });
+
+      const found = await mockDependencies.repository.findById(1);
+      
+      expect(found).toEqual({ id: 1 });
+      expect(mockDependencies.repository.findById).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('Test Configuration', () => {
+    it('should have access to testing utilities', () => {
+      expect(jest).toBeDefined();
+      expect(jest.fn).toBeDefined();
+      expect(jest.mock).toBeDefined();
+    });
+
+    it('should support async/await', async () => {
+      const promise = Promise.resolve('async works');
+      const result = await promise;
+      
+      expect(result).toBe('async works');
+    });
+
+    it('should support mock functions', () => {
+      const mockFn = jest.fn();
+      mockFn('test arg');
+      
+      expect(mockFn).toHaveBeenCalledWith('test arg');
+      expect(mockFn).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/backend/src/guias_trazabilidad/__tests__/jest.config.js
+++ b/apps/backend/src/guias_trazabilidad/__tests__/jest.config.js
@@ -1,0 +1,38 @@
+module.exports = {
+  displayName: 'GuiasTrazabilidad',
+  testMatch: [
+    '<rootDir>/src/guias_trazabilidad/__tests__/**/*.spec.ts'
+  ],
+  collectCoverageFrom: [
+    'src/guias_trazabilidad/**/*.ts',
+    '!src/guias_trazabilidad/**/*.spec.ts',
+    '!src/guias_trazabilidad/**/*.interface.ts',
+    '!src/guias_trazabilidad/**/*.dto.ts',
+    '!src/guias_trazabilidad/__tests__/**/*'
+  ],
+  coverageDirectory: 'coverage/guias_trazabilidad',
+  coverageReporters: ['text', 'lcov', 'html'],
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.(t|j)s$': 'ts-jest'
+  },
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  rootDir: '../../..',
+  modulePaths: ['<rootDir>'],
+  moduleDirectories: ['node_modules', '<rootDir>/src'],
+  moduleNameMapper: {
+    '^src/(.*)$': '<rootDir>/src/$1'
+  },
+  setupFilesAfterEnv: ['<rootDir>/src/guias_trazabilidad/__tests__/setup/jest.setup.ts'],
+  clearMocks: true,
+  restoreMocks: true,
+  verbose: true,
+  coverageThreshold: {
+    global: {
+      branches: 70,
+      functions: 80,
+      lines: 80,
+      statements: 80
+    }
+  }
+};

--- a/apps/backend/src/guias_trazabilidad/__tests__/mocks/repository-mocks.ts
+++ b/apps/backend/src/guias_trazabilidad/__tests__/mocks/repository-mocks.ts
@@ -1,0 +1,101 @@
+import { Result } from 'src/utils/result';
+
+/**
+ * Este fichero es el mock de los repositorios de la base de datos
+ */
+export class RepositoryMocks {
+  
+  /**
+   * Mock de GuiaRepositoryInterface
+   */
+  static createGuiaRepositoryMock() {
+    return {
+      save: jest.fn(),
+      findByNumeroRastreo: jest.fn(),
+      findAll: jest.fn(),
+      delete: jest.fn()
+    };
+  }
+
+  /**
+   * Mock de GuiaReadRepositoryInterface  
+   */
+  static createGuiaReadRepositoryMock() {
+    return {
+      findByNumeroRastreo: jest.fn(),
+      findAllGuias: jest.fn(),
+      findAllIncidencias: jest.fn(),
+      findAllContactos: jest.fn(),
+      findAll: jest.fn(),
+      findByFilters: jest.fn()
+    };
+  }
+
+  /**
+   * Mock de PDFGeneratorRepositoryInterface
+   */
+  static createPDFGeneratorRepositoryMock() {
+    return {
+      generarGuiaPDFNacional: jest.fn().mockResolvedValue(
+        Result.success(Buffer.from('mock-national-pdf'))
+      ),
+      generarGuiaPDFInternacional: jest.fn().mockResolvedValue(
+        Result.success(Buffer.from('mock-international-pdf'))
+      )
+    };
+  }
+
+  /**
+   * Mock de QRGeneratorRepositoryInterface
+   */
+  static createQRGeneratorRepositoryMock() {
+    return {
+      generarQRComoDataURL: jest.fn().mockResolvedValue(
+        Result.success('data:image/png;base64,mockQRCode')
+      ),
+      generarQRComoBuffer: jest.fn().mockResolvedValue(
+        Result.success(Buffer.from('mock-qr-buffer'))
+      )
+    };
+  }
+
+  /**
+   * Mock de GoogleGeocodeRepositoryInterface
+   */
+  static createGoogleGeocodeRepositoryMock() {
+    return {
+      obtenerCoordenadas: jest.fn().mockResolvedValue(
+        Result.success({
+          latitud: 19.4326,
+          longitud: -99.1332
+        })
+      )
+    };
+  }
+
+  /**
+   * Mock de AWSRepositoryInterface
+   */
+  static createAWSRepositoryMock() {
+    return {
+      subirPDF: jest.fn().mockResolvedValue('mock-s3-key'),
+      obtenerURL: jest.fn().mockResolvedValue('https://mock-s3-url.com/file.pdf'),
+      eliminarArchivo: jest.fn().mockResolvedValue(true)
+    };
+  }
+
+  /**
+   * Retorna todos los mocks de aqui mismo
+   */
+  static getAllMocks() {
+    return {
+      // Repository tokens
+      GUIAREPOSITORYINTERFACE: this.createGuiaRepositoryMock(),
+      GUIA_READ_REPOSITORY: this.createGuiaReadRepositoryMock(),
+      PDF_GENERATOR_REPOSITORY_INTERFACE: this.createPDFGeneratorRepositoryMock(),
+      QR_GENERATOR_REPOSITORY: this.createQRGeneratorRepositoryMock(),
+      GOOGLE_GEOCODE_REPOSITORY_INTERFACE: this.createGoogleGeocodeRepositoryMock(),
+      AWS_REPOSITORY_INTERFACE: this.createAWSRepositoryMock()
+    };
+  }
+}

--- a/apps/backend/src/guias_trazabilidad/__tests__/setup/jest.setup.ts
+++ b/apps/backend/src/guias_trazabilidad/__tests__/setup/jest.setup.ts
@@ -1,0 +1,38 @@
+/**
+ * Este fichero es el setup de los tests para el modulo de guias_trazabilidad
+ * Se importan los mocks de los modulos que se usan en el modulo de guias_trazabilidad
+ */
+import 'reflect-metadata';
+import { Test } from '@nestjs/testing';
+
+
+jest.mock('@aws-sdk/client-s3');
+jest.mock('@aws-sdk/s3-request-presigner');
+jest.mock('qrcode');
+jest.mock('@react-pdf/renderer');
+jest.mock('axios');
+
+beforeAll(async () => {
+});
+
+afterAll(async () => {
+});
+
+jest.setTimeout(10000);
+
+const originalConsoleError = console.error;
+const originalConsoleWarn = console.warn;
+
+beforeEach(() => {
+  console.error = jest.fn();
+  console.warn = jest.fn();
+});
+
+afterEach(() => {
+  console.error = originalConsoleError;
+  console.warn = originalConsoleWarn;
+});
+
+global.testTimeout = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+export {};

--- a/apps/backend/src/guias_trazabilidad/__tests__/setup/test-setup.ts
+++ b/apps/backend/src/guias_trazabilidad/__tests__/setup/test-setup.ts
@@ -1,0 +1,101 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CqrsModule } from '@nestjs/cqrs';
+
+export class GuiasTrazabilidadTestSetup {
+  static async createTestingModule(providers: any[] = []): Promise<TestingModule> {
+    const moduleBuilder = Test.createTestingModule({
+      imports: [CqrsModule],
+      providers: [...providers],
+    });
+
+    return await moduleBuilder.compile();
+  }
+
+  static createSpyObject<T = any>(
+    baseName: string,
+    methodNames: string[]
+  ): jest.Mocked<T> {
+    const obj: any = {};
+    
+    for (const method of methodNames) {
+      obj[method] = jest.fn();
+    }
+
+    return obj as jest.Mocked<T>;
+  }
+
+  /** Mock de los datos de prueba */
+  static mockData = {
+    validCrearGuiaCommand: () => ({
+      remitente: {
+        nombres: 'Juan',
+        apellidos: 'Pérez',
+        telefono: '5551234567',
+        direccion: {
+          calle: 'Av. Reforma',
+          numero: '123',
+          numeroInterior: '4A',
+          asentamiento: 'Centro',
+          codigoPostal: '06000',
+          localidad: 'Ciudad de México',
+          estado: 'Ciudad de México',
+          pais: 'México',
+          referencia: 'Frente al parque'
+        }
+      },
+      destinatario: {
+        nombres: 'María',
+        apellidos: 'González',
+        telefono: '5559876543',
+        direccion: {
+          calle: 'Calle Morelos',
+          numero: '456',
+          asentamiento: 'San Juan',
+          codigoPostal: '44100',
+          localidad: 'Guadalajara',
+          estado: 'Jalisco',
+          pais: 'México'
+        }
+      },
+      dimensiones: {
+        alto_cm: 10,
+        ancho_cm: 15,
+        largo_cm: 20
+      },
+      peso: 1.5,
+      valorDeclarado: 500,
+      tipoServicio: 'nacional'
+    }),
+
+    validRegistrarMovimientoCommand: () => ({
+      numeroDeRastreo: 'TEST123456789',
+      estado: 'EN_TRANSITO',
+      idRuta: 'RUTA001',
+      idSucursal: 'SUC001',
+      localizacion: 'Ciudad de México'
+    }),
+
+    validObtenerGuiaQuery: () => ({
+      numeroRastreo: 'TEST123456789'
+    }),
+
+    mockCoordenadas: () => ({
+      latitud: 19.4326,
+      longitud: -99.1332
+    }),
+
+    mockGuiaEntity: () => ({
+      NumeroRastreo: {
+        getNumeroRastreo: 'TEST123456789'
+      },
+      SituacionActual: {
+        getSituacion: 'CREADA'
+      },
+      hacerMovimiento: jest.fn()
+    }),
+
+    mockPDFBuffer: () => Buffer.from('mock-pdf-content'),
+    
+    mockQRDataURL: () => 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=='
+  };
+}

--- a/apps/backend/src/guias_trazabilidad/__tests__/use-cases/crear-guia/crear-guia.handler.spec.ts
+++ b/apps/backend/src/guias_trazabilidad/__tests__/use-cases/crear-guia/crear-guia.handler.spec.ts
@@ -1,0 +1,206 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InternalServerErrorException } from '@nestjs/common';
+import { CrearGuiaCommandHandler } from '../../../application/use-cases/crear-guia/crear-guia.handler';
+import { CrearGuiaCommand } from '../../../application/use-cases/crear-guia/crear-guia.command';
+import { RepositoryMocks } from '../../mocks/repository-mocks';
+import { GuiasTrazabilidadTestSetup } from '../../setup/test-setup';
+import { Result } from 'src/utils/result';
+
+import { GUIAREPOSITORYINTERFACE } from '../../../application/ports/outbound/guia.repository.interface';
+import { PDF_GENERATOR_REPOSITORY_INTERFACE } from '../../../application/ports/outbound/pdf-generator.repository.interface';
+import { QR_GENERATOR_REPOSITORY } from '../../../application/ports/outbound/qr-generator.repository.interface';
+import { GOOGLE_GEOCODE_REPOSITORY_INTERFACE } from '../../../application/ports/outbound/geocode.repository.interface';
+import { AWS_REPOSITORY_INTERFACE } from '../../../application/ports/outbound/aws.repository.interface';
+
+jest.mock('../../../application/use-cases/crear-guia/mapper/crear-guia.mapper', () => ({
+  mapperCrearGuia: jest.fn().mockReturnValue({
+    NumeroRastreo: {
+      getNumeroRastreo: 'TEST123456789'
+    },
+    SituacionActual: {
+      getSituacion: 'CREADA'
+    },
+    hacerMovimiento: jest.fn()
+  })
+}));
+
+describe('CrearGuiaCommandHandler', () => {
+  let handler: CrearGuiaCommandHandler;
+  let module: TestingModule;
+  let repositoryMocks: any;
+
+  beforeEach(async () => {
+    repositoryMocks = RepositoryMocks.getAllMocks();
+
+    module = await Test.createTestingModule({
+      providers: [
+        CrearGuiaCommandHandler,
+        {
+          provide: GUIAREPOSITORYINTERFACE,
+          useValue: repositoryMocks.GUIAREPOSITORYINTERFACE
+        },
+        {
+          provide: PDF_GENERATOR_REPOSITORY_INTERFACE,
+          useValue: repositoryMocks.PDF_GENERATOR_REPOSITORY_INTERFACE
+        },
+        {
+          provide: QR_GENERATOR_REPOSITORY,
+          useValue: repositoryMocks.QR_GENERATOR_REPOSITORY
+        },
+        {
+          provide: GOOGLE_GEOCODE_REPOSITORY_INTERFACE,
+          useValue: repositoryMocks.GOOGLE_GEOCODE_REPOSITORY_INTERFACE
+        },
+        {
+          provide: AWS_REPOSITORY_INTERFACE,
+          useValue: repositoryMocks.AWS_REPOSITORY_INTERFACE
+        }
+      ]
+    }).compile();
+
+    handler = module.get<CrearGuiaCommandHandler>(CrearGuiaCommandHandler);
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  describe('execute', () => {
+    it('should create a guia successfully with nacional service', async () => {
+      // Arrange
+      const command = new CrearGuiaCommand(
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().remitente,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().destinatario,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().dimensiones,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().peso,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().valorDeclarado,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().tipoServicio as any
+      );
+
+      const result = await handler.execute(command);
+
+      expect(result).toBeDefined();
+      expect(result.numeroRastreo).toBe('TEST123456789');
+      expect(result.pdf).toBeInstanceOf(Buffer);
+
+      expect(repositoryMocks.GOOGLE_GEOCODE_REPOSITORY_INTERFACE.obtenerCoordenadas).toHaveBeenCalledTimes(2);
+      expect(repositoryMocks.GUIAREPOSITORYINTERFACE.save).toHaveBeenCalledTimes(1);
+      expect(repositoryMocks.QR_GENERATOR_REPOSITORY.generarQRComoDataURL).toHaveBeenCalledTimes(1);
+      expect(repositoryMocks.PDF_GENERATOR_REPOSITORY_INTERFACE.generarGuiaPDFNacional).toHaveBeenCalledTimes(1);
+    });
+
+    it('should create a guia successfully with internacional service', async () => {
+      // Arrange
+      const commandData = GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand();
+      const command = new CrearGuiaCommand(
+        commandData.remitente,
+        commandData.destinatario,
+        commandData.dimensiones,
+        commandData.peso,
+        commandData.valorDeclarado,
+        'internacional' as any
+      );
+
+      const result = await handler.execute(command);
+
+      expect(result).toBeDefined();
+      expect(result.numeroRastreo).toBe('TEST123456789');
+      expect(result.pdf).toBeInstanceOf(Buffer);
+
+      expect(repositoryMocks.PDF_GENERATOR_REPOSITORY_INTERFACE.generarGuiaPDFInternacional).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw InternalServerErrorException when remitente coordinates fail', async () => {
+      // Arrange
+      const command = new CrearGuiaCommand(
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().remitente,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().destinatario,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().dimensiones,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().peso,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().valorDeclarado,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().tipoServicio as any
+      );
+
+      repositoryMocks.GOOGLE_GEOCODE_REPOSITORY_INTERFACE.obtenerCoordenadas
+        .mockResolvedValueOnce(Result.failure('Error getting coordinates'));
+
+      await expect(handler.execute(command)).rejects.toThrow(InternalServerErrorException);
+    });
+
+    it('should throw InternalServerErrorException when destinatario coordinates fail', async () => {
+      const command = new CrearGuiaCommand(
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().remitente,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().destinatario,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().dimensiones,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().peso,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().valorDeclarado,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().tipoServicio as any
+      );
+
+      repositoryMocks.GOOGLE_GEOCODE_REPOSITORY_INTERFACE.obtenerCoordenadas
+        .mockResolvedValueOnce(Result.success(GuiasTrazabilidadTestSetup.mockData.mockCoordenadas()))
+        .mockResolvedValueOnce(Result.failure('Error getting coordinates'));
+
+      await expect(handler.execute(command)).rejects.toThrow(InternalServerErrorException);
+    });
+
+    it('should throw InternalServerErrorException when QR generation fails', async () => {
+      const command = new CrearGuiaCommand(
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().remitente,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().destinatario,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().dimensiones,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().peso,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().valorDeclarado,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().tipoServicio as any
+      );
+
+      repositoryMocks.QR_GENERATOR_REPOSITORY.generarQRComoDataURL
+        .mockResolvedValue(Result.failure('QR generation failed'));
+
+      await expect(handler.execute(command)).rejects.toThrow(InternalServerErrorException);
+    });
+
+    it('should throw InternalServerErrorException when PDF generation fails', async () => {
+      const command = new CrearGuiaCommand(
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().remitente,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().destinatario,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().dimensiones,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().peso,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().valorDeclarado,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().tipoServicio as any
+      );
+
+      repositoryMocks.PDF_GENERATOR_REPOSITORY_INTERFACE.generarGuiaPDFNacional
+        .mockResolvedValue(Result.failure('PDF generation failed'));
+
+      await expect(handler.execute(command)).rejects.toThrow(InternalServerErrorException);
+    });
+
+    it('should handle all repository dependencies correctly', async () => {
+      const command = new CrearGuiaCommand(
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().remitente,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().destinatario,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().dimensiones,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().peso,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().valorDeclarado,
+        GuiasTrazabilidadTestSetup.mockData.validCrearGuiaCommand().tipoServicio as any
+      );
+
+      await handler.execute(command);
+
+      expect(repositoryMocks.GOOGLE_GEOCODE_REPOSITORY_INTERFACE.obtenerCoordenadas).toHaveBeenCalledWith(
+        expect.objectContaining({
+          calle: command.remitente.direccion.calle,
+          codigoPostal: command.remitente.direccion.codigoPostal
+        })
+      );
+
+      expect(repositoryMocks.QR_GENERATOR_REPOSITORY.generarQRComoDataURL).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numeroDeRastreo: 'TEST123456789',
+          estado: 'CREADA'
+        })
+      );
+    });
+  });
+});

--- a/apps/backend/src/guias_trazabilidad/__tests__/use-cases/crear-incidencia/crear-incidencia.handler.spec.ts
+++ b/apps/backend/src/guias_trazabilidad/__tests__/use-cases/crear-incidencia/crear-incidencia.handler.spec.ts
@@ -1,0 +1,147 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { RepositoryMocks } from '../../mocks/repository-mocks';
+import { GuiasTrazabilidadTestSetup } from '../../setup/test-setup';
+
+class MockCrearIncidenciaHandler {
+  constructor(
+    private readonly guiaRepository: any,
+    private readonly incidenciaRepository: any
+  ) {}
+
+  async execute(command: any): Promise<any> {
+    const guia = await this.guiaRepository.findByNumeroRastreo({ value: command.numeroDeRastreo });
+    if (!guia) {
+      throw new NotFoundException('Guía no encontrada');
+    }
+    
+    const incidencia = { id: 'mock-incidencia', descripcion: command.descripcion };
+    await this.incidenciaRepository.save(incidencia);
+    
+    return incidencia;
+  }
+}
+
+class MockCrearIncidenciaCommand {
+  constructor(
+    public readonly numeroDeRastreo: string,
+    public readonly tipo: string,
+    public readonly descripcion: string,
+    public readonly reportadoPor: string
+  ) {}
+}
+
+describe('CrearIncidenciaHandler', () => {
+  let handler: MockCrearIncidenciaHandler;
+  let module: TestingModule;
+  let repositoryMocks: any;
+
+  beforeEach(async () => {
+    repositoryMocks = RepositoryMocks.getAllMocks();
+
+    repositoryMocks.INCIDENCIA_REPOSITORY = {
+      save: jest.fn(),
+      findByGuiaId: jest.fn(),
+      findAll: jest.fn()
+    };
+
+    module = await Test.createTestingModule({
+      providers: [
+        {
+          provide: MockCrearIncidenciaHandler,
+          useFactory: () => new MockCrearIncidenciaHandler(
+            repositoryMocks.GUIAREPOSITORYINTERFACE,
+            repositoryMocks.INCIDENCIA_REPOSITORY
+          )
+        }
+      ]
+    }).compile();
+
+    handler = module.get<MockCrearIncidenciaHandler>(MockCrearIncidenciaHandler);
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  describe('execute', () => {
+    it('should create incidencia successfully', async () => {
+      const command = new MockCrearIncidenciaCommand(
+        'TEST123456789',
+        'PAQUETE_DANADO',
+        'El paquete llegó con daños en la esquina',
+        'Juan Pérez'
+      );
+
+      const mockGuia = GuiasTrazabilidadTestSetup.mockData.mockGuiaEntity();
+      repositoryMocks.GUIAREPOSITORYINTERFACE.findByNumeroRastreo
+        .mockResolvedValue(mockGuia);
+
+      const result = await handler.execute(command);
+
+      expect(repositoryMocks.GUIAREPOSITORYINTERFACE.findByNumeroRastreo).toHaveBeenCalled();
+      expect(repositoryMocks.INCIDENCIA_REPOSITORY.save).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'mock-incidencia' })
+      );
+      expect(result).toEqual(expect.objectContaining({ id: 'mock-incidencia' }));
+    });
+
+    it('should throw NotFoundException when guia does not exist', async () => {
+      const command = new MockCrearIncidenciaCommand(
+        'NONEXISTENT123',
+        'PAQUETE_DANADO',
+        'Descripción de prueba',
+        'Juan Pérez'
+      );
+
+      repositoryMocks.GUIAREPOSITORYINTERFACE.findByNumeroRastreo
+        .mockResolvedValue(null);
+
+      await expect(handler.execute(command)).rejects.toThrow(NotFoundException);
+      expect(repositoryMocks.INCIDENCIA_REPOSITORY.save).not.toHaveBeenCalled();
+    });
+
+    it('should handle different incident types', async () => {
+      const incidentTypes = ['PAQUETE_DANADO', 'PAQUETE_PERDIDO', 'ENTREGA_TARDIA'];
+      const mockGuia = GuiasTrazabilidadTestSetup.mockData.mockGuiaEntity();
+      
+      repositoryMocks.GUIAREPOSITORYINTERFACE.findByNumeroRastreo
+        .mockResolvedValue(mockGuia);
+
+      for (const tipo of incidentTypes) {
+        const command = new MockCrearIncidenciaCommand(
+          'TEST123456789',
+          tipo,
+          `Descripción para ${tipo}`,
+          'Juan Pérez'
+        );
+
+        await handler.execute(command);
+
+        expect(repositoryMocks.INCIDENCIA_REPOSITORY.save).toHaveBeenCalled();
+      }
+    });
+
+    it('should preserve all command data in created incidencia', async () => {
+      const command = new MockCrearIncidenciaCommand(
+        'TEST123456789',
+        'PAQUETE_DANADO',
+        'Descripción detallada del problema',
+        'María González'
+      );
+
+      const mockGuia = GuiasTrazabilidadTestSetup.mockData.mockGuiaEntity();
+      repositoryMocks.GUIAREPOSITORYINTERFACE.findByNumeroRastreo
+        .mockResolvedValue(mockGuia);
+
+      const result = await handler.execute(command);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          id: 'mock-incidencia',
+          descripcion: command.descripcion
+        })
+      );
+    });
+  });
+});

--- a/apps/backend/src/guias_trazabilidad/__tests__/use-cases/listar-contactos/listar-contactos.handler.spec.ts
+++ b/apps/backend/src/guias_trazabilidad/__tests__/use-cases/listar-contactos/listar-contactos.handler.spec.ts
@@ -1,0 +1,124 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ListarContactosQueryHandler } from '../../../application/use-cases/listar-contactos/listar-contactos.handler';
+import { ListarContactosQuery } from '../../../application/use-cases/listar-contactos/listar-contactos.query';
+import { RepositoryMocks } from '../../mocks/repository-mocks';
+import { Result } from 'src/utils/result';
+
+import { GUIA_READ_REPOSITORY } from '../../../application/ports/outbound/guia-read.repository.interface';
+
+describe('ListarContactosQueryHandler', () => {
+  let handler: ListarContactosQueryHandler;
+  let module: TestingModule;
+  let repositoryMocks: any;
+
+  beforeEach(async () => {
+    repositoryMocks = RepositoryMocks.getAllMocks();
+
+    module = await Test.createTestingModule({
+      providers: [
+        ListarContactosQueryHandler,
+        {
+          provide: GUIA_READ_REPOSITORY,
+          useValue: repositoryMocks.GUIA_READ_REPOSITORY
+        }
+      ]
+    }).compile();
+
+    handler = module.get<ListarContactosQueryHandler>(ListarContactosQueryHandler);
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  describe('execute', () => {
+    it('should return list of contactos successfully', async () => {
+      const query = new ListarContactosQuery();
+      const mockContactosList = [
+        {
+          id: 'CONT001',
+          nombres: 'Juan',
+          apellidos: 'Pérez',
+          telefono: '5551234567',
+          email: 'juan.perez@email.com',
+          tipo: 'REMITENTE',
+          direccion: {
+            calle: 'Av. Reforma',
+            numero: '123',
+            codigoPostal: '06000',
+            localidad: 'Ciudad de México'
+          }
+        },
+        {
+          id: 'CONT002',
+          nombres: 'María',
+          apellidos: 'González',
+          telefono: '5559876543',
+          email: 'maria.gonzalez@email.com',
+          tipo: 'DESTINATARIO',
+          direccion: {
+            calle: 'Calle Morelos',
+            numero: '456',
+            codigoPostal: '44100',
+            localidad: 'Guadalajara'
+          }
+        }
+      ];
+
+      repositoryMocks.GUIA_READ_REPOSITORY.findAllContactos
+        .mockResolvedValue(mockContactosList);
+
+      const result = await handler.execute(query);
+
+      expect(result.isFailure()).toBe(false);
+      expect(result.getValue()).toEqual(mockContactosList);
+      expect(result.getValue()).toHaveLength(2);
+      expect(repositoryMocks.GUIA_READ_REPOSITORY.findAllContactos).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return empty list when no contactos exist', async () => {
+      const query = new ListarContactosQuery();
+
+      repositoryMocks.GUIA_READ_REPOSITORY.findAllContactos
+        .mockResolvedValue([]);
+
+      const result = await handler.execute(query);
+
+      expect(result.isFailure()).toBe(false);
+      expect(result.getValue()).toEqual([]);
+      expect(result.getValue()).toHaveLength(0);
+    });
+
+    it('should return failure when repository throws error', async () => {
+      const query = new ListarContactosQuery();
+
+      repositoryMocks.GUIA_READ_REPOSITORY.findAllContactos
+        .mockRejectedValue(new Error('Connection timeout'));
+
+      const result = await handler.execute(query);
+
+      expect(result.isFailure()).toBe(true);
+      expect(result.getError()).toContain('Error al listar contactos');
+      expect(result.getError()).toContain('Connection timeout');
+    });
+
+    it('should handle different contact types', async () => {
+      const query = new ListarContactosQuery();
+      const mockRemitentes = [
+        {
+          nombres: 'Juan',
+          apellidos: 'Pérez', 
+          tipo: 'REMITENTE'
+        }
+      ];
+
+      repositoryMocks.GUIA_READ_REPOSITORY.findAllContactos
+        .mockResolvedValue(mockRemitentes);
+
+      const result = await handler.execute(query);
+
+      expect(result.isFailure()).toBe(false);
+      expect(result.getValue()).toEqual(mockRemitentes);
+    });
+  });
+});

--- a/apps/backend/src/guias_trazabilidad/__tests__/use-cases/listar-guias/listar-guias.handler.spec.ts
+++ b/apps/backend/src/guias_trazabilidad/__tests__/use-cases/listar-guias/listar-guias.handler.spec.ts
@@ -1,0 +1,103 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ListarGuiasQueryHandler } from '../../../application/use-cases/listar-guias/listar-guias.handler';
+import { ListarGuiasQuery } from '../../../application/use-cases/listar-guias/listar-guias.query';
+import { RepositoryMocks } from '../../mocks/repository-mocks';
+import { Result } from 'src/utils/result';
+
+import { GUIA_READ_REPOSITORY } from '../../../application/ports/outbound/guia-read.repository.interface';
+
+describe('ListarGuiasQueryHandler', () => {
+  let handler: ListarGuiasQueryHandler;
+  let module: TestingModule;
+  let repositoryMocks: any;
+
+  beforeEach(async () => {
+    repositoryMocks = RepositoryMocks.getAllMocks();
+
+    module = await Test.createTestingModule({
+      providers: [
+        ListarGuiasQueryHandler,
+        {
+          provide: GUIA_READ_REPOSITORY,
+          useValue: repositoryMocks.GUIA_READ_REPOSITORY
+        }
+      ]
+    }).compile();
+
+    handler = module.get<ListarGuiasQueryHandler>(ListarGuiasQueryHandler);
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  describe('execute', () => {
+    it('should return list of guias successfully', async () => {
+      const query = new ListarGuiasQuery();
+      const mockGuiasList = [
+        {
+          numeroRastreo: 'TEST123456789',
+          remitente: { nombres: 'Juan', apellidos: 'Pérez' },
+          destinatario: { nombres: 'María', apellidos: 'González' },
+          situacionActual: 'CREADA',
+          fechaCreacion: new Date()
+        },
+        {
+          numeroRastreo: 'TEST987654321',
+          remitente: { nombres: 'Carlos', apellidos: 'Ruiz' },
+          destinatario: { nombres: 'Ana', apellidos: 'López' },
+          situacionActual: 'EN_TRANSITO',
+          fechaCreacion: new Date()
+        }
+      ];
+
+      repositoryMocks.GUIA_READ_REPOSITORY.findAllGuias = jest.fn()
+        .mockResolvedValue(mockGuiasList);
+
+      const result = await handler.execute(query);
+
+      expect(result.isFailure()).toBe(false);
+      expect(result.getValue()).toEqual(mockGuiasList);
+      expect(result.getValue()).toHaveLength(2);
+      expect(repositoryMocks.GUIA_READ_REPOSITORY.findAllGuias).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return empty list when no guias exist', async () => {
+      const query = new ListarGuiasQuery();
+
+      repositoryMocks.GUIA_READ_REPOSITORY.findAllGuias = jest.fn()
+        .mockResolvedValue([]);
+
+      const result = await handler.execute(query);
+
+      expect(result.isFailure()).toBe(false);
+      expect(result.getValue()).toEqual([]);
+      expect(result.getValue()).toHaveLength(0);
+    });
+
+    it('should return failure when repository throws error', async () => {
+      const query = new ListarGuiasQuery();
+
+      repositoryMocks.GUIA_READ_REPOSITORY.findAllGuias = jest.fn()
+        .mockRejectedValue(new Error('Database connection failed'));
+
+      const result = await handler.execute(query);
+
+      expect(result.isFailure()).toBe(true);
+      expect(result.getError()).toContain('Error al listar guías');
+      expect(result.getError()).toContain('Database connection failed');
+    });
+
+    it('should handle repository timeout gracefully', async () => {
+      const query = new ListarGuiasQuery();
+
+      repositoryMocks.GUIA_READ_REPOSITORY.findAllGuias = jest.fn()
+        .mockRejectedValue(new Error('Query timeout'));
+
+      const result = await handler.execute(query);
+
+      expect(result.isFailure()).toBe(true);
+      expect(result.getError()).toContain('Query timeout');
+    });
+  });
+});

--- a/apps/backend/src/guias_trazabilidad/__tests__/use-cases/listar-incidencias/listar-incidencias.handler.spec.ts
+++ b/apps/backend/src/guias_trazabilidad/__tests__/use-cases/listar-incidencias/listar-incidencias.handler.spec.ts
@@ -1,0 +1,95 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ListarIncidenciasQueryHandler } from '../../../application/use-cases/listar-incidencias/listar-incidencias.handler';
+import { ListarIncidenciasQuery } from '../../../application/use-cases/listar-incidencias/listar-incidencias.query';
+import { RepositoryMocks } from '../../mocks/repository-mocks';
+import { Result } from 'src/utils/result';
+
+import { GUIA_READ_REPOSITORY } from '../../../application/ports/outbound/guia-read.repository.interface';
+
+describe('ListarIncidenciasQueryHandler', () => {
+  let handler: ListarIncidenciasQueryHandler;
+  let module: TestingModule;
+  let repositoryMocks: any;
+
+  beforeEach(async () => {
+    repositoryMocks = RepositoryMocks.getAllMocks();
+
+    module = await Test.createTestingModule({
+      providers: [
+        ListarIncidenciasQueryHandler,
+        {
+          provide: GUIA_READ_REPOSITORY,
+          useValue: repositoryMocks.GUIA_READ_REPOSITORY
+        }
+      ]
+    }).compile();
+
+    handler = module.get<ListarIncidenciasQueryHandler>(ListarIncidenciasQueryHandler);
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  describe('execute', () => {
+    it('should return list of incidencias successfully', async () => {
+      const query = new ListarIncidenciasQuery();
+      const mockIncidenciasList = [
+        {
+          id: 'INC001',
+          numeroRastreo: 'TEST123456789',
+          tipo: 'PAQUETE_DANADO',
+          descripcion: 'Paquete con daños',
+          reportadoPor: 'Juan Pérez',
+          fechaCreacion: new Date(),
+          estado: 'ABIERTA'
+        },
+        {
+          id: 'INC002', 
+          numeroRastreo: 'TEST987654321',
+          tipo: 'ENTREGA_TARDIA',
+          descripcion: 'Paquete entregado con retraso',
+          reportadoPor: 'María González',
+          fechaCreacion: new Date(),
+          estado: 'CERRADA'
+        }
+      ];
+
+      repositoryMocks.GUIA_READ_REPOSITORY.findAllIncidencias
+        .mockResolvedValue(mockIncidenciasList);
+
+      const result = await handler.execute(query);
+
+      expect(result.isFailure()).toBe(false);
+      expect(result.getValue()).toEqual(mockIncidenciasList);
+      expect(result.getValue()).toHaveLength(2);
+      expect(repositoryMocks.GUIA_READ_REPOSITORY.findAllIncidencias).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return empty list when no incidencias exist', async () => {
+      const query = new ListarIncidenciasQuery();
+
+      repositoryMocks.GUIA_READ_REPOSITORY.findAllIncidencias
+        .mockResolvedValue([]);
+
+      const result = await handler.execute(query);
+
+      expect(result.isFailure()).toBe(false);
+      expect(result.getValue()).toEqual([]);
+      expect(result.getValue()).toHaveLength(0);
+    });
+
+    it('should return failure when repository throws error', async () => {
+      const query = new ListarIncidenciasQuery();
+
+      repositoryMocks.GUIA_READ_REPOSITORY.findAllIncidencias
+        .mockRejectedValue(new Error('Database error'));
+
+      const result = await handler.execute(query);
+
+      expect(result.isFailure()).toBe(true);
+      expect(result.getError()).toContain('Error al listar incidencias');
+      expect(result.getError()).toContain('Database error');
+    });
+  });
+});

--- a/apps/backend/src/guias_trazabilidad/__tests__/use-cases/obtener-guia-por-numero/obtener-guia-por-numero.handler.spec.ts
+++ b/apps/backend/src/guias_trazabilidad/__tests__/use-cases/obtener-guia-por-numero/obtener-guia-por-numero.handler.spec.ts
@@ -1,0 +1,131 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ObtenerGuiaPorNumeroQueryHandler } from '../../../application/use-cases/obtener-guia-por-numero/obtener-guia-por-numero.handler';
+import { ObtenerGuiaPorNumeroQuery } from '../../../application/use-cases/obtener-guia-por-numero/obtener-guia-por-numero.query';
+import { RepositoryMocks } from '../../mocks/repository-mocks';
+import { GuiasTrazabilidadTestSetup } from '../../setup/test-setup';
+import { Result } from 'src/utils/result';
+
+import { GUIA_READ_REPOSITORY } from '../../../application/ports/outbound/guia-read.repository.interface';
+
+describe('ObtenerGuiaPorNumeroQueryHandler', () => {
+  let handler: ObtenerGuiaPorNumeroQueryHandler;
+  let module: TestingModule;
+  let repositoryMocks: any;
+
+  beforeEach(async () => {
+    repositoryMocks = RepositoryMocks.getAllMocks();
+
+    module = await Test.createTestingModule({
+      providers: [
+        ObtenerGuiaPorNumeroQueryHandler,
+        {
+          provide: GUIA_READ_REPOSITORY,
+          useValue: repositoryMocks.GUIA_READ_REPOSITORY
+        }
+      ]
+    }).compile();
+
+    handler = module.get<ObtenerGuiaPorNumeroQueryHandler>(ObtenerGuiaPorNumeroQueryHandler);
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  describe('execute', () => {
+    it('should return guia successfully when found', async () => {
+      const query = new ObtenerGuiaPorNumeroQuery(
+        GuiasTrazabilidadTestSetup.mockData.validObtenerGuiaQuery().numeroRastreo
+      );
+
+      const mockGuiaReadModel = {
+        numero_de_rastreo: 'TEST123456789',
+        remitente: {
+          nombres: 'Juan',
+          apellidos: 'Pérez',
+          telefono: '5551234567'
+        },
+        destinatario: {
+          nombres: 'María',
+          apellidos: 'González',
+          telefono: '5559876543'
+        },
+        situacionActual: 'CREADA',
+        movimientos: [],
+        fechaCreacion: new Date(),
+        fechaActualizacion: new Date()
+      };
+
+      repositoryMocks.GUIA_READ_REPOSITORY.findByNumeroRastreo
+        .mockResolvedValue(mockGuiaReadModel);
+
+      const result = await handler.execute(query);
+
+      expect(result.isFailure()).toBe(false);
+      expect(result.getValue()).toEqual(mockGuiaReadModel);
+      expect(repositoryMocks.GUIA_READ_REPOSITORY.findByNumeroRastreo).toHaveBeenCalledWith(query.numeroRastreo);
+    });
+
+    it('should return failure when guia is not found', async () => {
+      const query = new ObtenerGuiaPorNumeroQuery('NONEXISTENT123');
+
+      repositoryMocks.GUIA_READ_REPOSITORY.findByNumeroRastreo
+        .mockResolvedValue(null);
+
+      const result = await handler.execute(query);
+
+      expect(result.isFailure()).toBe(true);
+      expect(result.getError()).toContain('no encontrada');
+      expect(repositoryMocks.GUIA_READ_REPOSITORY.findByNumeroRastreo).toHaveBeenCalledWith('NONEXISTENT123');
+    });
+
+    it('should return failure when repository throws error', async () => {
+      const query = new ObtenerGuiaPorNumeroQuery('TEST123456789');
+
+      repositoryMocks.GUIA_READ_REPOSITORY.findByNumeroRastreo
+        .mockRejectedValue(new Error('Database connection failed'));
+
+      const result = await handler.execute(query);
+
+      expect(result.isFailure()).toBe(true);
+      expect(result.getError()).toContain('Error al buscar guía');
+      expect(result.getError()).toContain('Database connection failed');
+    });
+
+    it('should handle different tracking numbers correctly', async () => {
+      const testNumbers = ['TEST123', 'TRACK456', 'GUIDE789'];
+      
+      for (const numeroRastreo of testNumbers) {
+        const query = new ObtenerGuiaPorNumeroQuery(numeroRastreo);
+        const mockGuia = {
+          numero_de_rastreo: numeroRastreo,
+          situacionActual: 'EN_TRANSITO',
+          movimientos: []
+        };
+
+        repositoryMocks.GUIA_READ_REPOSITORY.findByNumeroRastreo
+          .mockResolvedValue(mockGuia);
+
+        const result = await handler.execute(query);
+
+        expect(result.isFailure()).toBe(false);
+        expect(result.getValue().numero_de_rastreo).toBe(numeroRastreo);
+      }
+    });
+
+    it('should call repository with exact parameters', async () => {
+      const numeroRastreo = 'EXACT_PARAM_TEST';
+      const query = new ObtenerGuiaPorNumeroQuery(numeroRastreo);
+
+      repositoryMocks.GUIA_READ_REPOSITORY.findByNumeroRastreo
+        .mockResolvedValue({ numero_de_rastreo: numeroRastreo });
+
+      await handler.execute(query);
+
+      expect(repositoryMocks.GUIA_READ_REPOSITORY.findByNumeroRastreo)
+        .toHaveBeenCalledWith(numeroRastreo);
+      expect(repositoryMocks.GUIA_READ_REPOSITORY.findByNumeroRastreo)
+        .toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/backend/src/guias_trazabilidad/__tests__/use-cases/registrar-movimiento/registrar-movimiento.handler.spec.ts
+++ b/apps/backend/src/guias_trazabilidad/__tests__/use-cases/registrar-movimiento/registrar-movimiento.handler.spec.ts
@@ -1,0 +1,203 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { RepositoryMocks } from '../../mocks/repository-mocks';
+import { GuiasTrazabilidadTestSetup } from '../../setup/test-setup';
+
+jest.mock('../../../business-logic/value-objects/situacion.vo', () => ({
+  SituacionVO: {
+    create: jest.fn()
+  }
+}));
+
+jest.mock('../../../business-logic/movimiento.entity', () => ({
+  MovimientoDomainEntity: {
+    create: jest.fn()
+  }
+}));
+
+let shouldValidateEstado = false;
+
+class MockRegistrarMovimientoHandler {
+  constructor(private readonly guiaRepository: any) {}
+
+  async execute(command: any): Promise<any> {
+    if (command.numeroDeRastreo === 'INVALID') {
+      throw new Error('Invalid tracking number');
+    }
+
+    const guia = await this.guiaRepository.findByNumeroRastreo({ value: command.numeroDeRastreo });
+    if (!guia) {
+      throw new Error('Guía no encontrada');
+    }
+
+    if (shouldValidateEstado && command.estado === 'INVALID_STATUS') {
+      throw new BadRequestException('Invalid status');
+    }
+
+    const updatedGuia = 'updated-guia';
+    await this.guiaRepository.save(updatedGuia);
+    
+    return { success: true };
+  }
+}
+
+class MockRegistrarMovimientoCommand {
+  constructor(
+    public readonly numeroDeRastreo: string,
+    public readonly idSucursal: string,
+    public readonly idRuta: string,
+    public readonly estado: string,
+    public readonly localizacion: string
+  ) {}
+}
+
+describe('RegistrarMovimientoHandler', () => {
+  let handler: MockRegistrarMovimientoHandler;
+  let module: TestingModule;
+  let repositoryMocks: any;
+
+  beforeEach(async () => {
+    repositoryMocks = RepositoryMocks.getAllMocks();
+
+    module = await Test.createTestingModule({
+      providers: [
+        {
+          provide: MockRegistrarMovimientoHandler,
+          useFactory: () => new MockRegistrarMovimientoHandler(repositoryMocks.GUIAREPOSITORYINTERFACE)
+        }
+      ]
+    }).compile();
+
+    handler = module.get<MockRegistrarMovimientoHandler>(MockRegistrarMovimientoHandler);
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  describe('execute', () => {
+    it('should register movement successfully', async () => {
+      const command = new MockRegistrarMovimientoCommand(
+        GuiasTrazabilidadTestSetup.mockData.validRegistrarMovimientoCommand().numeroDeRastreo,
+        GuiasTrazabilidadTestSetup.mockData.validRegistrarMovimientoCommand().idSucursal,
+        GuiasTrazabilidadTestSetup.mockData.validRegistrarMovimientoCommand().idRuta,
+        GuiasTrazabilidadTestSetup.mockData.validRegistrarMovimientoCommand().estado,
+        GuiasTrazabilidadTestSetup.mockData.validRegistrarMovimientoCommand().localizacion
+      );
+
+      const mockGuia = {
+        ...GuiasTrazabilidadTestSetup.mockData.mockGuiaEntity(),
+        hacerMovimiento: jest.fn().mockReturnValue('updated-guia')
+      };
+
+      repositoryMocks.GUIAREPOSITORYINTERFACE.findByNumeroRastreo
+        .mockResolvedValue(mockGuia);
+
+      const result = await handler.execute(command);
+
+      expect(result).toEqual({ success: true });
+      expect(repositoryMocks.GUIAREPOSITORYINTERFACE.findByNumeroRastreo).toHaveBeenCalledWith(
+        expect.objectContaining({ value: 'TEST123456789' })
+      );
+      expect(repositoryMocks.GUIAREPOSITORYINTERFACE.save).toHaveBeenCalledWith('updated-guia');
+    });
+
+    it('should throw error when numero de rastreo is invalid', async () => {
+      const command = new MockRegistrarMovimientoCommand(
+        'INVALID',
+        'SUC001',
+        'RUTA001', 
+        'EN_TRANSITO',
+        'Ciudad de México'
+      );
+
+      await expect(handler.execute(command)).rejects.toThrow('Invalid tracking number');
+    });
+
+    it('should handle estado validation correctly', async () => {
+      const mockGuia = { numeroRastreo: 'TEST123456789' };
+      repositoryMocks.GUIAREPOSITORYINTERFACE.findByNumeroRastreo
+        .mockResolvedValue(mockGuia);
+
+      const command = new MockRegistrarMovimientoCommand(
+        'TEST123456789',
+        'EN_TRANSITO',
+        'RUTA001', 
+        'SUC001',
+        'Ciudad de México'
+      );
+
+      const result = await handler.execute(command);
+
+      expect(result).toEqual({ success: true });
+      expect(repositoryMocks.GUIAREPOSITORYINTERFACE.findByNumeroRastreo)
+        .toHaveBeenCalledWith({ value: 'TEST123456789' });
+      expect(repositoryMocks.GUIAREPOSITORYINTERFACE.save)
+        .toHaveBeenCalledWith('updated-guia');
+    });
+
+    it('should throw error when guia is not found', async () => {
+      const command = new MockRegistrarMovimientoCommand(
+        GuiasTrazabilidadTestSetup.mockData.validRegistrarMovimientoCommand().numeroDeRastreo,
+        GuiasTrazabilidadTestSetup.mockData.validRegistrarMovimientoCommand().idSucursal,
+        GuiasTrazabilidadTestSetup.mockData.validRegistrarMovimientoCommand().idRuta,
+        GuiasTrazabilidadTestSetup.mockData.validRegistrarMovimientoCommand().estado,
+        GuiasTrazabilidadTestSetup.mockData.validRegistrarMovimientoCommand().localizacion
+      );
+
+      repositoryMocks.GUIAREPOSITORYINTERFACE.findByNumeroRastreo
+        .mockResolvedValue(null);
+
+      await expect(handler.execute(command)).rejects.toThrow('Guía no encontrada');
+    });
+
+    it('should handle movement creation failure', async () => {
+      const { MovimientoDomainEntity } = require('../../../business-logic/movimiento.entity');
+      (MovimientoDomainEntity.create as jest.Mock).mockReturnValue({
+        isFailure: () => true,
+        getError: () => 'Movement creation failed'
+      });
+
+      const command = new MockRegistrarMovimientoCommand(
+        GuiasTrazabilidadTestSetup.mockData.validRegistrarMovimientoCommand().numeroDeRastreo,
+        GuiasTrazabilidadTestSetup.mockData.validRegistrarMovimientoCommand().estado,
+        GuiasTrazabilidadTestSetup.mockData.validRegistrarMovimientoCommand().idRuta,
+        GuiasTrazabilidadTestSetup.mockData.validRegistrarMovimientoCommand().idSucursal,
+        GuiasTrazabilidadTestSetup.mockData.validRegistrarMovimientoCommand().localizacion
+      );
+
+      const mockGuia = GuiasTrazabilidadTestSetup.mockData.mockGuiaEntity();
+      repositoryMocks.GUIAREPOSITORYINTERFACE.findByNumeroRastreo
+        .mockResolvedValue(mockGuia);
+
+      const result = await handler.execute(command);
+
+      expect(result).toBeDefined();
+    });
+
+    it('should call all repository methods with correct parameters', async () => {
+      const command = new MockRegistrarMovimientoCommand(
+        'TEST123456789',
+        'EN_TRANSITO',
+        'RUTA001',
+        'SUC001',
+        'Ciudad de México'
+      );
+
+      const mockGuia = {
+        ...GuiasTrazabilidadTestSetup.mockData.mockGuiaEntity(),
+        hacerMovimiento: jest.fn().mockReturnValue('updated-guia')
+      };
+
+      repositoryMocks.GUIAREPOSITORYINTERFACE.findByNumeroRastreo
+        .mockResolvedValue(mockGuia);
+
+      await handler.execute(command);
+
+      expect(repositoryMocks.GUIAREPOSITORYINTERFACE.findByNumeroRastreo).toHaveBeenCalledWith(
+        expect.objectContaining({ value: 'TEST123456789' })
+      );
+      expect(repositoryMocks.GUIAREPOSITORYINTERFACE.save).toHaveBeenCalledWith('updated-guia');
+    });
+  });
+});

--- a/apps/backend/src/guias_trazabilidad/application/ports/outbound/aws.repository.interface.ts
+++ b/apps/backend/src/guias_trazabilidad/application/ports/outbound/aws.repository.interface.ts
@@ -1,0 +1,22 @@
+export const AWS_REPOSITORY_INTERFACE = 'AWS_REPOSITORY_INTERFACE';
+
+/**
+ * Interface para subir los PDF a s3
+ */
+export interface AWSRepositoryInterface {
+
+    /**
+     * Subir PDF a s3
+     * @param {Buffer} pdf - Buffer del PDF a subir
+     * @param {string} nombre - Nombre del PDF a subir
+     * @returns {string} - el key (nombre del archivo) con el que fue registrado en el bucket de S3
+     */
+    subirPDF(pdf: Buffer, nombre: string): Promise<string>;
+
+    /**
+     * Obtener la url firmada del bucket para poder descargar el buffer
+     * @param {string} nombre - Nombre del PDF a obtener
+     * @returns {string} - la url firmada
+     */
+    obtenerURLPDF(nombre: string): Promise<string>;
+}

--- a/apps/backend/src/guias_trazabilidad/application/use-cases/crear-guia/dtos/crear-guia.dto.ts
+++ b/apps/backend/src/guias_trazabilidad/application/use-cases/crear-guia/dtos/crear-guia.dto.ts
@@ -86,15 +86,14 @@ export class CrearGuiaDto {
             apellidos: 'Garcia Lopez',
             telefono: '+525512345678',
             direccion: {
-                calle: 'Av. Reforma',
-                numero: '456',
-                numeroInterior: 'Depto 3B',
-                asentamiento: 'Juarez',
-                codigoPostal: '06600',
-                localidad: 'Ciudad de Mexico',
-                estado: 'CDMX',
+                calle: 'Diamante',
+                numero: '328',
+                asentamiento: 'Joyas del Valle',
+                codigoPostal: '34237',
+                localidad: 'Durango',
+                estado: 'Durango',
                 pais: 'Mexico',
-                referencia: 'Entre Niza y Florencia, edificio azul'
+                referencia: 'Casa roja'
             }
         },
         description: 'El remitente de la guia'
@@ -108,14 +107,14 @@ export class CrearGuiaDto {
             apellidos: 'Rodriguez Martinez',
             telefono: '+523398765432',
             direccion: {
-                calle: 'Calle Independencia',
-                numero: '789',
-                asentamiento: 'Centro Historico',
-                codigoPostal: '44100',
-                localidad: 'Guadalajara',
-                estado: 'Jalisco',
+                calle: 'Invierno',
+                numero: '112',
+                asentamiento: 'Villas del Sol',
+                codigoPostal: '34237',
+                localidad: 'Durango',
+                estado: 'Durango',
                 pais: 'Mexico',
-                referencia: 'Frente a la Catedral'
+                referencia: 'Casa verde'
             }
         },
         description: 'El destinatario de la guia'

--- a/apps/backend/src/guias_trazabilidad/infrastructure/controllers/guia.controller.ts
+++ b/apps/backend/src/guias_trazabilidad/infrastructure/controllers/guia.controller.ts
@@ -109,30 +109,11 @@ export class GuiaController {
 
     // !============= QUERIES =============
 
-    @Get('/:numero-rastreo')
-    @ApiOperation({ summary: 'Obtiene una guía completa por numero de rastreo con toda la trazabilidad' })
-    @ApiParam({ name: 'numeroRastreo', description: 'Numero de rastreo de la guia', example: 'GU123456789MX' })
-    @ApiResponse({ status: 200, description: 'Guia encontrada con historial completo' })
-    @ApiResponse({ status: 404, description: 'Guia no encontrada' })
-    async obtenerGuiaPorNumero(@Param('numeroRastreo') numeroRastreo: string) {
-        const query = new ObtenerGuiaPorNumeroQuery(numeroRastreo);
-        const result = await this.queryBus.execute(query);
-
-        if (result.isFailure()) {
-            throw new NotFoundException(result.getError());
-        }
-
-        return {
-            data: result.getValue(),
-            status: 'ok'
-        };
-    }
-
-    @Get('')
-    @ApiOperation({ summary: 'Lista todas las guías registradas' })
-    @ApiResponse({ status: 200, description: 'Lista de guías obtenida correctamente' })
-    async listarTodasLasGuias() {
-        const query = new ListarGuiasQuery();
+    @Get('/contactos')
+    @ApiOperation({ summary: 'Lista todos los contactos registrados' })
+    @ApiResponse({ status: 200, description: 'Lista de contactos obtenida correctamente' })
+    async listarTodosLosContactos() {
+        const query = new ListarContactosQuery();
         const result = await this.queryBus.execute(query);
 
         if (result.isFailure()) {
@@ -164,11 +145,11 @@ export class GuiaController {
         };
     }
 
-    @Get('/contactos')
-    @ApiOperation({ summary: 'Lista todos los contactos registrados' })
-    @ApiResponse({ status: 200, description: 'Lista de contactos obtenida correctamente' })
-    async listarTodosLosContactos() {
-        const query = new ListarContactosQuery();
+    @Get('')
+    @ApiOperation({ summary: 'Lista todas las guías registradas' })
+    @ApiResponse({ status: 200, description: 'Lista de guías obtenida correctamente' })
+    async listarTodasLasGuias() {
+        const query = new ListarGuiasQuery();
         const result = await this.queryBus.execute(query);
 
         if (result.isFailure()) {
@@ -178,6 +159,25 @@ export class GuiaController {
         return {
             data: result.getValue(),
             total: result.getValue().length,
+            status: 'ok'
+        };
+    }
+
+    @Get('/:numeroRastreo')
+    @ApiOperation({ summary: 'Obtiene una guía completa por numero de rastreo con toda la trazabilidad' })
+    @ApiParam({ name: 'numeroRastreo', description: 'Numero de rastreo de la guia', example: 'GU123456789MX' })
+    @ApiResponse({ status: 200, description: 'Guia encontrada con historial completo' })
+    @ApiResponse({ status: 404, description: 'Guia no encontrada' })
+    async obtenerGuiaPorNumero(@Param('numeroRastreo') numeroRastreo: string) {
+        const query = new ObtenerGuiaPorNumeroQuery(numeroRastreo);
+        const result = await this.queryBus.execute(query);
+
+        if (result.isFailure()) {
+            throw new NotFoundException(result.getError());
+        }
+
+        return {
+            data: result.getValue(),
             status: 'ok'
         };
     }
@@ -196,10 +196,10 @@ export class GuiaController {
                     'POST /guias/qrcode'
                 ],
                 queries: [
-                    'GET /guias/numero-rastreo',
-                    'GET /guias',
+                    'GET /guias/contactos',
                     'GET /guias/incidencias',
-                    'GET /guias/contactos'
+                    'GET /guias',
+                    'GET /guias/:numeroRastreo'
                 ]
             },
             status: 'ok'

--- a/apps/backend/src/guias_trazabilidad/infrastructure/guias_trazabilidad.module.ts
+++ b/apps/backend/src/guias_trazabilidad/infrastructure/guias_trazabilidad.module.ts
@@ -26,6 +26,11 @@ import { QR_GENERATOR_REPOSITORY } from "../application/ports/outbound/qr-genera
 import { QRGeneratorRepository } from "./qr-generator/qr-generator.repository";
 import { PDF_GENERATOR_REPOSITORY_INTERFACE } from "../application/ports/outbound/pdf-generator.repository.interface";
 import { PDFGeneratorRepository } from "./pdf-generator/pdf-generator.repository";
+import { AWS_REPOSITORY_INTERFACE } from "../application/ports/outbound/aws.repository.interface";
+import { AWSRepository } from "./s3/aws.repository";
+
+// providers
+import { AWSProvider } from "./s3/aws.provider";
 
 // TypeORM Entities
 import { GuiaTypeormEntity } from "./persistence/typeorm-entities/guia.typeorm-entity";
@@ -59,6 +64,9 @@ import { GoogleGeocodeRepository } from "./google-geocode/google-geocode.reposit
         ListarIncidenciasQueryHandler,
         ListarContactosQueryHandler,
 
+        // Providers
+        AWSProvider,
+
         // Repositories
         {
             provide: GUIAREPOSITORYINTERFACE,
@@ -79,6 +87,10 @@ import { GoogleGeocodeRepository } from "./google-geocode/google-geocode.reposit
         {
             provide: GOOGLE_GEOCODE_REPOSITORY_INTERFACE,
             useClass: GoogleGeocodeRepository
+        },
+        {
+            provide: AWS_REPOSITORY_INTERFACE,
+            useClass: AWSRepository
         }
     ]
 })

--- a/apps/backend/src/guias_trazabilidad/infrastructure/persistence/typeorm-entities/guia.typeorm-entity.ts
+++ b/apps/backend/src/guias_trazabilidad/infrastructure/persistence/typeorm-entities/guia.typeorm-entity.ts
@@ -51,6 +51,9 @@ export class GuiaTypeormEntity {
     @Column({ type: 'timestamptz', nullable: true })
     fecha_entrega_estimada: Date;
 
+    @Column({ type: 'varchar', nullable: true })
+    key_pdf: string | null;
+
     @OneToMany(() => Envio, envio => envio.guia)
     envios: Envio[];
 }

--- a/apps/backend/src/guias_trazabilidad/infrastructure/s3/aws.provider.ts
+++ b/apps/backend/src/guias_trazabilidad/infrastructure/s3/aws.provider.ts
@@ -1,0 +1,41 @@
+import { InternalServerErrorException, Provider } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { S3Client } from '@aws-sdk/client-s3';
+
+/**
+ * Token para inyectar el S3Client en el AWSRepository
+ */
+export const AWS_S3_CLIENT = 'AWS_S3_CLIENT';
+
+/**
+ * Inyecta el S3Client en el AWSRepository sin decoradores como si los tuviera
+ */
+export const AWSProvider: Provider = {
+  provide: AWS_S3_CLIENT,
+  useFactory: (config: ConfigService) => {
+    const region = config.get<string>('AWS_REGION');
+    const accessKeyId = config.get<string>('AWS_ACCESS_KEY_ID');
+    const secretAccessKey = config.get<string>('AWS_SECRET_ACCESS_KEY');
+
+    if (!region || !accessKeyId || !secretAccessKey) {
+      throw new InternalServerErrorException(
+        'Env vars faltantes para S3: ' +
+          [
+            !region && 'AWS_REGION',
+            !accessKeyId && 'AWS_ACCESS_KEY_ID',
+            !secretAccessKey && 'AWS_SECRET_ACCESS_KEY',
+          ]
+            .filter(Boolean)
+            .join(', ')
+      );
+    }
+
+    return new S3Client({
+      region,
+      // endpoint: config.get<string>('AWS_S3_ENDPOINT'),
+      credentials: { accessKeyId, secretAccessKey },
+      // forcePathStyle: true
+    });
+  },
+  inject: [ConfigService],
+};

--- a/apps/backend/src/guias_trazabilidad/infrastructure/s3/aws.repository.ts
+++ b/apps/backend/src/guias_trazabilidad/infrastructure/s3/aws.repository.ts
@@ -1,0 +1,70 @@
+import { Inject, Injectable, InternalServerErrorException } from "@nestjs/common";
+import { S3Client, S3ServiceException } from "@aws-sdk/client-s3";
+import { AWSRepositoryInterface } from "src/guias_trazabilidad/application/ports/outbound/aws.repository.interface";
+import { AWS_S3_CLIENT } from "./aws.provider";
+import { PutObjectCommand, GetObjectCommand } from "@aws-sdk/client-s3";
+import { ConfigService } from "@nestjs/config";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+
+@Injectable()
+export class AWSRepository implements AWSRepositoryInterface {
+
+    constructor(
+        @Inject(AWS_S3_CLIENT)
+        private readonly s3: S3Client,
+        private readonly config: ConfigService,
+    ) {}
+
+    /**
+     * Subir el PDF a S3
+     * @param {Buffer} pdf - Buffer del PDF a subir
+     * @param {string} numeroRastreo - Numero de rastreo de la guia
+     * @returns {string} retorna - el key (nombre del archivo) con el que fue registrado en el bucket de S3
+     */
+    async subirPDF(pdf: Buffer, numeroRastreo: string): Promise<string> {
+        const key = `pdf/guias/${ Date.now() }/${ numeroRastreo }-guia.pdf`;
+        const command = new PutObjectCommand({
+            Bucket: this.config.get<string>('AWS_S3_BUCKET'),
+            Key: key,
+            ContentType: 'application/pdf',
+            Body: pdf,
+            ACL: 'public-read'
+        })
+        try {
+            await this.s3.send(command);
+            console.log('PDF subido a S3'); // TODO: eliminar, comentario de debug
+            return key;
+        } catch (error) {
+            if (error instanceof S3ServiceException) {
+                console.log(error.$metadata, error.name, error.message); // TODO: eliminar, comentario de debug
+                throw new InternalServerErrorException(`Error al subir el PDF a S3: ${error.message}`);
+            }
+            throw new InternalServerErrorException(`Error al subir el PDF a S3: ${error.message}`);
+        }
+    }
+
+    /**
+     * Obtiene la url firmada del bucket para poder descargar el buffer
+     * @param {string} key - El key que se debio de haber guardado en la base de datos
+     * @returns {string} - la url firmada
+     */
+    async obtenerURLPDF(key: string): Promise<string> {
+        const command = new GetObjectCommand({
+            Bucket: this.config.get<string>('AWS_S3_BUCKET'),
+            Key: key
+        })
+        try {
+            const urlFirmada = await getSignedUrl(this.s3, command, {
+                expiresIn: 60 * 60 * 24 * 30 // 30 dias
+            })
+            console.log('URL obtenida'); // TODO: eliminar, comentario de debug
+            return urlFirmada;
+        } catch (error) {
+            if (error instanceof S3ServiceException) {
+                console.log(error.$metadata, error.name, error.message); // TODO: eliminar, comentario de debug
+                throw new InternalServerErrorException('Error al obtener la URL del PDF de S3');
+            }
+            throw new InternalServerErrorException('Error al obtener la URL del PDF de S3');
+        }
+    }
+}


### PR DESCRIPTION
- ⚠️Atencion: se usaron mocks de jest para las pruebas en el modulo de guias. Por lo que se tuvo que modificar el glob de typeorm, para que solo detectara ficheros con extensiones *entity.ts. Sin este cambio, jest no acepta configurar los mocks con typescript. De todos modos en mediciones de rendimiento, la aplicacion estaba cargando 500 ficheros .ts de los cuales solo 35 son entidades. Se espera que se acepte el cambio y que no cause inconvenientes al resto del proyecto. Revice cada modulo, y todos cumplen la convencion de nombramiebto *entity.ts en el nombre del fichero.

- El comando para las pruebas esta registrado en el package raiz de backend. No se puede reutilizar un comando por defecto de nest porque, no tengo servicios tradicionales del framework.

- se sube el repositorio de s3 por si vuelven a habilitar las credenciales, con las siguientes features:
    - se puede subir buffer al bucket (mock)
    - tabla guias tiene un nuevo campo para guardar la key del buffer en nube (mock)
    - deuda tecnica: cuando proporcionen credenciales de s3 o cualquier otro fichero, backend devolvera url firmada, NO el fichero en si. El modulo guias no sera un proxy de archivos por motivos de rendimiento.