### PR TITLE
Add new components

### DIFF
--- a/apps/correos-movil/components/ui/Button.tsx
+++ b/apps/correos-movil/components/ui/Button.tsx
@@ -1,0 +1,141 @@
+import { StyleProp } from "react-native";
+import { TextStyle } from "react-native";
+import { StyleSheet, Text, Pressable, PressableProps } from "react-native";
+
+const backgroundColors: Record<string, string> = {
+  default: "#DE1484",
+  secondary: "#F9FAFB",
+  outline: "transparent",
+};
+const textColors: Record<string, string> = {
+  default: "#FFFFFF",
+  secondary: "#374151",
+  outline: "#DE1484",
+};
+const borderColors: Record<string, string> = {
+  default: "transparent",
+  secondary: "transparent",
+  outline: "#DE1484",
+};
+const sizeStyles: Record<string, Record<string, number>> = {
+  small: { height: 36, paddingHorizontal: 12 },
+  default: { height: 48, paddingHorizontal: 16 },
+  large: { height: 60, paddingHorizontal: 20 },
+};
+
+/**
+ * Font sizes for each button size
+ */
+const fontSizes: Record<string, number> = {
+  small: 14,
+  default: 16,
+  large: 18,
+};
+
+export type ButtonProps = PressableProps & {
+  /**
+   * Variant of the button
+   * - `"default"`: solid primary color
+   * - `"secondary"`: lighter background
+   * - `"outline"`: border button with transparent background
+   * @default "default"
+   */
+  type?: "default" | "secondary" | "outline";
+
+  /**
+   * Size of the button
+   * - `"small"`: height 36, font size 14
+   * - `"default"`: height 48, font size 16
+   * - `"large"`: height 60, font size 18
+   * @default "default"
+   */
+  size?: "small" | "default" | "large";
+
+  /**
+   * Text or elements to render inside the button
+   */
+  children: React.ReactNode;
+
+  /**
+   * Custom styles for the text inside the button
+   */
+  textStyles?: StyleProp<TextStyle>;
+};
+
+/**
+ * Button component
+ *
+ * A customizable button that supports multiple types and sizes.
+ * You can override the button and text styles using `style` and `textStyles` respectively.
+ * All native `Pressable` props are supported (e.g., `onPress`, `disabled`).
+ *
+ * ### Example Usage
+ * ```tsx
+ * import { Button } from './Button';
+ *
+ * // Default button
+ * <Button type="default" size="large" onPress={() => console.log('Clicked')}>
+ *   Submit
+ * </Button>
+ *
+ * // Secondary small button
+ * <Button type="secondary" size="small">
+ *   Cancel
+ * </Button>
+ *
+ * // Outline button with custom text style
+ * <Button type="outline" size="default" textStyles={{ fontWeight: 'bold' }}>
+ *   Learn More
+ * </Button>
+ * ```
+ */
+export function Button({
+  type = "default",
+  size = "default",
+  children,
+  style,
+  textStyles,
+  ...props
+}: ButtonProps) {
+  const bgColor = backgroundColors[type];
+  const txtColor = textColors[type];
+  const borderColor = borderColors[type];
+  const btnSize = sizeStyles[size];
+  const fontSize = fontSizes[size];
+
+  return (
+    <Pressable
+      style={(state) => [
+        styles.button,
+        btnSize,
+        {
+          backgroundColor: bgColor,
+          borderColor,
+          borderWidth: type === "outline" ? 1 : 0,
+        },
+        typeof style === "function" ? style(state) : style,
+      ]}
+      {...props}
+    >
+      {typeof children === "string" ? (
+        <Text style={[styles.text, { color: txtColor, fontSize }, textStyles]}>
+          {children}
+        </Text>
+      ) : (
+        children
+      )}
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    borderRadius: 8,
+    borderCurve: "continuous",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  text: {
+    textAlign: "center",
+  },
+});

--- a/apps/correos-movil/components/ui/Input.tsx
+++ b/apps/correos-movil/components/ui/Input.tsx
@@ -1,0 +1,133 @@
+import { View, TextInput, StyleSheet, TextInputProps } from "react-native";
+
+/**
+ * Props for the `Input` component.
+ */
+export type InputProps = TextInputProps & {
+  /**
+   * Optional icon to display inside the input.
+   * Can be any React node, for example an icon from `lucide-react-native`.
+   *
+   * Example:
+   * ```tsx
+   * import { SearchIcon } from "lucide-react-native";
+   * <Input icon={<SearchIcon size={22} color="#374151" />} />
+   * ```
+   */
+  icon?: React.ReactNode;
+
+  /**
+   * Position of the icon inside the input.
+   * - `"left"`: icon appears on the left side (default)
+   * - `"right"`: icon appears on the right side
+   *
+   * Example:
+   * ```tsx
+   * <Input
+   *   icon={<SearchIcon size={22} color="#374151" />}
+   *   iconPosition="right"
+   * />
+   * ```
+   * @default "left"
+   */
+  iconPosition?: "left" | "right";
+};
+
+/**
+ * Input component
+ *
+ * A customizable text input that supports an optional icon on either side.
+ * All props from the native `TextInput` component are supported, so you can
+ * use things like `value`, `onChangeText`, `keyboardType`, etc.
+ *
+ * You can also override styles using the `style` prop.
+ *
+ * ### Example Usage
+ * ```tsx
+ * import { Input } from "./Input";
+ * import { SearchIcon } from "lucide-react-native";
+ *
+ * export function Example() {
+ *   return (
+ *     <Input
+ *       placeholder="Search..."
+ *       icon={<SearchIcon size={22} color="#374151" />}
+ *       iconPosition="right"
+ *       value={searchText}
+ *       onChangeText={setSearchText}
+ *       style={{ backgroundColor: "#FFF0F0", borderColor: "#FF0000" }}
+ *     />
+ *   );
+ * }
+ * ```
+ */
+export function Input({
+  style,
+  icon,
+  placeholderTextColor,
+  iconPosition = "left",
+  ...props
+}: InputProps) {
+  return (
+    <View style={styles.container}>
+      {icon && iconPosition === "left" && (
+        <View style={styles.iconContainerLeft}>{icon}</View>
+      )}
+      <TextInput
+        style={[
+          styles.input,
+          icon && iconPosition === "left"
+            ? styles.inputWithLeftIcon
+            : undefined,
+          icon && iconPosition === "right"
+            ? styles.inputWithRightIcon
+            : undefined,
+          style,
+        ]}
+        placeholderTextColor={placeholderTextColor || "#9CA3AF"}
+        {...props}
+      />
+      {icon && iconPosition === "right" && (
+        <View style={styles.iconContainerRight}>{icon}</View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: "relative",
+    width: "100%",
+  },
+  iconContainerLeft: {
+    position: "absolute",
+    left: 15,
+    top: 0,
+    bottom: 0,
+    justifyContent: "center",
+  },
+  iconContainerRight: {
+    position: "absolute",
+    right: 15,
+    top: 0,
+    bottom: 0,
+    justifyContent: "center",
+  },
+  input: {
+    backgroundColor: "#F9FAFB",
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+    height: 48,
+    width: "100%",
+    borderRadius: 8,
+    borderCurve: "continuous",
+    color: "#374151",
+    paddingHorizontal: 15,
+  },
+  inputWithLeftIcon: {
+    paddingLeft: 45,
+  },
+  inputWithRightIcon: {
+    paddingRight: 45,
+  },
+});

--- a/apps/correos-movil/components/ui/Input.tsx
+++ b/apps/correos-movil/components/ui/Input.tsx
@@ -105,6 +105,7 @@ const styles = StyleSheet.create({
     top: 0,
     bottom: 0,
     justifyContent: "center",
+    zIndex: 1,
   },
   iconContainerRight: {
     position: "absolute",

--- a/apps/correos-movil/components/ui/index.ts
+++ b/apps/correos-movil/components/ui/index.ts
@@ -1,0 +1,2 @@
+export { Input } from "./Input";
+export { Button } from "./Button";


### PR DESCRIPTION
This PR adds a reusable component to the app. Components are built with React Native primitives and accept the same props as their underlying elements, like TextInput and Pressable.

## Input
```
 <Input
   placeholder="Search..."
   icon={<SearchIcon size={22} color="#374151" />}
   iconPosition="right"
   value={searchText}
   onChangeText={setSearchText}
   style={{ backgroundColor: "#FFF0F0", borderColor: "#FF0000" }}
/>
```

## Button
```
<Button size="large" onPress={() => console.log('Clicked')}>
   Submit
</Button>
```