### PR TITLE
fix-backend: cambio de correo institucional

### DIFF
--- a/apps/backend/src/enviar-correos/enviar-correos.service.ts
+++ b/apps/backend/src/enviar-correos/enviar-correos.service.ts
@@ -27,7 +27,7 @@ export class EnviarCorreosService {
 
   async enviarConfirmacion(user: IEmail): Promise<void> {
     const mailOptions = {
-      from: '"Correos México" <correosdemexico@unipolidgo.edu.mx>',
+      from: '"Correos México" <correosdemexicoclic@gmail.com>',
       to: user.correo,
       subject: 'Confirma tu cuenta - Correos México',
       html: `
@@ -49,7 +49,7 @@ export class EnviarCorreosService {
 
   async enviarAdvertenciaEliminacion(user: IEmail): Promise<void> {
     const mailOptions = {
-      from: '"Correos México" <correosdemexico@unipolidgo.edu.mx>',
+      from: '"Correos México" <correosdemexicoclic@gmail.com>',
       to: user.correo,
       subject: 'Tu cuenta será eliminada pronto',
       html: `


### PR DESCRIPTION
Se ha cambiado la dirección de correo electrónico «de» en los métodos enviarConfirmacion y enviarAdvertenciaEliminacion a correosdemexicoclic@gmail.com para mantener la coherencia y mejorar la capacidad de entrega.
fix #74
