### PR TITLE
fix-frontend/desajuste visual en los banners

### DIFF
--- a/apps/correos-movil/screens/usuario/HomePage/HomeUser.tsx
+++ b/apps/correos-movil/screens/usuario/HomePage/HomeUser.tsx
@@ -617,11 +617,11 @@ const styles = StyleSheet.create({
   carouselImage: {
     width: '90%',
     height: '100%',
-    resizeMode: 'contain',
-    borderRadius: moderateScale(8),
+    resizeMode: 'cover',
+    borderRadius: moderateScale(10),
     alignSelf: 'center',
-
-  },
+    overflow: 'hidden',
+},
   pagination: {
     flexDirection: 'row',
     justifyContent: 'center',

--- a/apps/correos-movil/screens/usuario/HomePage/HomeUser.tsx
+++ b/apps/correos-movil/screens/usuario/HomePage/HomeUser.tsx
@@ -613,13 +613,11 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     height: screenHeight * 0.22,
   },
-  // Ajustes para la imagen del carrusel
   carouselImage: {
-    width: '90%',
+    width: '100%',
     height: '100%',
-    resizeMode: 'contain',
-    borderRadius: moderateScale(12),
-    alignSelf: 'center',
+    resizeMode: 'cover',
+    borderRadius: moderateScale(8),
   },
   pagination: {
     flexDirection: 'row',

--- a/apps/correos-movil/screens/usuario/HomePage/HomeUser.tsx
+++ b/apps/correos-movil/screens/usuario/HomePage/HomeUser.tsx
@@ -613,11 +613,14 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     height: screenHeight * 0.22,
   },
+  //Ajustar margen del carrusel
   carouselImage: {
-    width: '100%',
+    width: '90%',
     height: '100%',
-    resizeMode: 'cover',
+    resizeMode: 'contain',
     borderRadius: moderateScale(8),
+    alignSelf: 'center',
+
   },
   pagination: {
     flexDirection: 'row',

--- a/apps/correos-movil/screens/usuario/HomePage/HomeUser.tsx
+++ b/apps/correos-movil/screens/usuario/HomePage/HomeUser.tsx
@@ -613,11 +613,13 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     height: screenHeight * 0.22,
   },
+  // Ajustes para la imagen del carrusel
   carouselImage: {
-    width: '100%',
+    width: '90%',
     height: '100%',
-    resizeMode: 'cover',
-    borderRadius: moderateScale(8),
+    resizeMode: 'contain',
+    borderRadius: moderateScale(12),
+    alignSelf: 'center',
   },
   pagination: {
     flexDirection: 'row',


### PR DESCRIPTION
Se corrigió el desajuste visual en los banners de la pantalla principal.
- Los banners rozaban los bordes de la pantalla.
- Se ajustaron márgenes y proporciones para mantener una buena alineación.


<img width="300" alt="c3 jpg (1)" src="https://github.com/user-attachments/assets/dac2e241-cb0b-4a34-92c2-e3fbedb5ccc0" />

<img width="300" alt="c3 jpg (1)" src="https://github.com/user-attachments/assets/39a91bf1-b224-4d97-a560-f4d990f7f23d" />
