### PR TITLE
chore: migrate from s3 to r2

### DIFF
--- a/apps/backend/src/guias_trazabilidad/infrastructure/s3/aws.provider.ts
+++ b/apps/backend/src/guias_trazabilidad/infrastructure/s3/aws.provider.ts
@@ -16,14 +16,16 @@ export const AWSProvider: Provider = {
     const region = config.get<string>('AWS_REGION');
     const accessKeyId = config.get<string>('AWS_ACCESS_KEY_ID');
     const secretAccessKey = config.get<string>('AWS_SECRET_ACCESS_KEY');
+    const endpoint = config.get<string>('AWS_S3_ENDPOINT');
 
-    if (!region || !accessKeyId || !secretAccessKey) {
+    if (!region || !accessKeyId || !secretAccessKey || !endpoint) {
       throw new InternalServerErrorException(
         'Env vars faltantes para S3: ' +
           [
             !region && 'AWS_REGION',
             !accessKeyId && 'AWS_ACCESS_KEY_ID',
             !secretAccessKey && 'AWS_SECRET_ACCESS_KEY',
+            !endpoint && 'AWS_S3_ENDPOINT',
           ]
             .filter(Boolean)
             .join(', ')
@@ -32,6 +34,7 @@ export const AWSProvider: Provider = {
 
     return new S3Client({
       region,
+      endpoint,
       credentials: { accessKeyId, secretAccessKey },
     });
   },

--- a/apps/backend/src/upload-image/s3.provider.ts
+++ b/apps/backend/src/upload-image/s3.provider.ts
@@ -8,11 +8,13 @@ export const S3Provider: Provider = {
     const region = config.get<string>('AWS_REGION');
     const accessKeyId = config.get<string>('AWS_ACCESS_KEY_ID');
     const secretAccessKey = config.get<string>('AWS_SECRET_ACCESS_KEY');
+    const endpoint = config.get<string>('AWS_S3_ENDPOINT');
 
     const missing = [
       !region && 'AWS_REGION',
       !accessKeyId && 'AWS_ACCESS_KEY_ID',
       !secretAccessKey && 'AWS_SECRET_ACCESS_KEY',
+      !endpoint && 'AWS_S3_ENDPOINT',
     ].filter(Boolean);
 
     if (missing.length > 0) {
@@ -21,6 +23,7 @@ export const S3Provider: Provider = {
 
     return new S3Client({
       region: region!,
+      endpoint: endpoint!,
       credentials: {
         accessKeyId: accessKeyId!,
         secretAccessKey: secretAccessKey!,

--- a/apps/backend/src/upload-image/upload-image.service.ts
+++ b/apps/backend/src/upload-image/upload-image.service.ts
@@ -14,8 +14,9 @@ export class  UploadImageService {
     const region = this.config.get<string>('AWS_REGION');
     const accessKeyId = this.config.get<string>('AWS_ACCESS_KEY_ID');
     const secretAccessKey = this.config.get<string>('AWS_SECRET_ACCESS_KEY');
+    const endpoint = config.get<string>('AWS_S3_ENDPOINT');
 
-    if (!bucket || !region || !accessKeyId || !secretAccessKey) {
+    if (!bucket || !region || !accessKeyId || !secretAccessKey || !endpoint) {
       throw new Error(
         'Faltan variables de entorno requeridas: ' +
           [
@@ -23,6 +24,7 @@ export class  UploadImageService {
             !region && 'AWS_REGION',
             !accessKeyId && 'AWS_ACCESS_KEY_ID',
             !secretAccessKey && 'AWS_SECRET_ACCESS_KEY',
+            !endpoint && 'AWS_S3_ENDPOINT',
           ]
             .filter(Boolean)
             .join(', ')
@@ -33,6 +35,7 @@ export class  UploadImageService {
     this.region = region;
     this.s3 = new S3Client({
       region,
+      endpoint,
       credentials: {
         accessKeyId,
         secretAccessKey,
@@ -70,8 +73,7 @@ export class  UploadImageService {
 
     await this.s3.send(cmd);
 
-    const publicUrl = `https://${this.bucket}.s3.${this.region}.amazonaws.com/${key}`;
-    return publicUrl;
+    return `https://correos-storage.emmanuelbayona.dev/${key}`;
   }
 
   async uploadEvidenceDistributor(file: Express.Multer.File): Promise<string> {
@@ -85,7 +87,6 @@ export class  UploadImageService {
 
     await this.s3.send(cmd);
 
-    const publicUrl = `https://${this.bucket}.s3.${this.region}.amazonaws.com/${key}`;
-    return publicUrl;
+    return `https://correos-storage.emmanuelbayona.dev/${key}`;
   }
 }

--- a/apps/backend/src/viewdoc/viewdoc.service.ts
+++ b/apps/backend/src/viewdoc/viewdoc.service.ts
@@ -15,9 +15,11 @@ export class ViewdocService {
     const region = this.config.get<string>('AWS_REGION')!;
     const accessKeyId = this.config.get<string>('AWS_ACCESS_KEY_ID')!;
     const secretAccessKey = this.config.get<string>('AWS_SECRET_ACCESS_KEY')!;
+    const endpoint = config.get<string>('AWS_S3_ENDPOINT');
 
     this.s3 = new S3Client({
       region,
+      endpoint,
       credentials: { accessKeyId, secretAccessKey },
       forcePathStyle: true,
     });


### PR DESCRIPTION
Migrate S3 uploads to R2, since they are compatible, we only need to update our env credentials and modify the returned public url, everything else remains intact